### PR TITLE
Fixed served filename

### DIFF
--- a/inc/static/StaticHandler.hpp
+++ b/inc/static/StaticHandler.hpp
@@ -27,7 +27,7 @@ class StaticHandler
 	std::string	_errorPageHtml(HttpStatus const& status) const;
 	std::string	_welcomePageHtml() const;
 	std::string	_autoindexHtml() const;
-	std::string	_getCurrentDateLocal(time_t time) const;
+
 
 	std::string	_getMime(const std::string& filePath);
 	std::string	_getMimeFromPath(const std::string& filePath);

--- a/inc/utils/utils.hpp
+++ b/inc/utils/utils.hpp
@@ -43,6 +43,7 @@ namespace utils {
 
 
 	std::string	readFile(std::string const&);
+	std::string	getFileName(const std::string& path);
 	std::string	getFileExtension(std::string const&);
 	std::string	toLowerCase(std::string const&);
 	std::vector<std::string>	split(std::string const&, char);

--- a/src/cgi/CgiHandler.cpp
+++ b/src/cgi/CgiHandler.cpp
@@ -255,7 +255,8 @@ void	CgiHandler::_buildEnvp(Request const& req, std::string const& locRoot)
 	tmp["REQUEST_METHOD"] = req.getMethod();
 	tmp["SCRIPT_FILENAME"] = _scriptName; // absolute path
 	tmp["SCRIPT_NAME"] = req.getScriptName(); // relative path
-    tmp["PATH_INFO"] = req.getPathInfo();
+	tmp["PATH_INFO"] = req.getPath().empty() ? "/" : req.getPath(); //full path for the tester to work
+	tmp["PATH_TRANSLATED"] = locRoot + tmp["PATH_INFO"];
 	tmp["QUERY_STRING"] = req.getQueryString();
 	tmp["CONTENT_TYPE"] = req.getContentType();
 	tmp["CONTENT_LENGTH"] = utils::str(req.getBody().length());
@@ -264,6 +265,14 @@ void	CgiHandler::_buildEnvp(Request const& req, std::string const& locRoot)
 	tmp["GATEWAY_INTERFACE"] = "CGI/1.1";
 	tmp["SERVER_PROTOCOL"] = req.getVersion();
 	tmp["SERVER_SOFTWARE"] = Const::SERVER_SOFTWARE;
+	// Additional variables from old subject requirements to pass ubuntu_tester
+	tmp["AUTH_TYPE"] = "";
+	tmp["REMOTE_ADDR"] = "127.0.0.1";
+	tmp["REMOTE_IDENT"] = ""; 
+	tmp["REMOTE_USER"] = "";
+	tmp["REQUEST_URI"] = req.getUri();
+	tmp["SERVER_NAME"] = "localhost";
+	tmp["SERVER_PORT"] = "8080";
 	// HTTP headers (prefixed with HTTP_)
 	Headers headers = req.getHeaders();
 	for (Headers::const_iterator it = headers.begin(); it != headers.end(); ++it)

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -175,13 +175,15 @@ std::string Response::_buildHeaders() const
 		headerStream << "Location: " << _headers.find("location")->second << "\r\n";
 	if (_headers.find("cache-control") != _headers.end())
 		headerStream << "Cache-Control: " << _headers.find("cache-control")->second << "\r\n";
+	if (_headers.find("content-disposition") != _headers.end())
+		headerStream << "Content-Disposition: " << _headers.find("content-disposition")->second << "\r\n";
 	for (std::map<std::string, std::string>::const_iterator it = _headers.begin();
 		it != _headers.end(); ++it)
 		{
 			const std::string& key = it->first;
 			if (key != "server" && key != "date" && key != "content-type" &&
 				key != "content-length" && key != "connection" &&
-				key != "location" && key != "cache-control")
+				key != "location" && key != "cache-control" && key != "content-disposition")
 					headerStream << key << ": " << it->second << "\r\n";
 		}
 	return headerStream.str();

--- a/src/static/StaticHandler.cpp
+++ b/src/static/StaticHandler.cpp
@@ -238,14 +238,6 @@ std::string	StaticHandler::_autoindexHtml() const
 	return html.str();
 }
 
-std::string StaticHandler::_getCurrentDateLocal(time_t time) const
-{
-	struct tm* timeinfo = localtime(&time);
-	char buffer[20];
-	strftime(buffer, sizeof(buffer), "%d-%b-%Y %H:%M", timeinfo);
-	return buffer;
-}
-
 std::string StaticHandler::_errorPageHtml(HttpStatus const& status) const
 {
 	return std::string(
@@ -327,6 +319,8 @@ Response	StaticHandler::_serveFile()
 	Response resp;
 	resp.setStatus(HttpStatus("ok"));
 	resp.setContentType(_getMimeFromPath(_finalPath));
+	std::string filename = utils::getFileName(_finalPath);
+	resp.setHeader("Content-Disposition", "inline; filename=\"" + filename + "\"");
 	resp.setBody(content);
 	return resp;
 }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -152,6 +152,14 @@ std::string	utils::readFile(std::string const& path)
 	return buffer.str();
 }
 
+std::string	utils::getFileName(const std::string& path)
+{
+	size_t lastSlash = path.find_last_of('/');
+	if (lastSlash != std::string::npos)
+		return path.substr(lastSlash + 1);
+	return path;
+}
+
 /**
  * Returns the file extension, including the dot
  *


### PR DESCRIPTION
Small fix for the file served in case we have an index file :

- Now it correctly shows the file name downloaded, instead of "download"

Other :

- Removed reduntant function `_getCurrentDateLocal()` since it's now inside `utils` serving both purposes for Response and File listing.

One note about the filename fix, I found this from my main website source I've been using https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Disposition :

<img width="771" height="114" alt="image" src="https://github.com/user-attachments/assets/13f07533-8fcb-4f78-90b8-0c609496dc3f" />

Which tells me that the way we had it before is normal behaviour. What do you thin, do we keep this fix inside this PR or we keep the previous ?

TODO :

Deal with the shit tester!

UPDATE :

- Added to CGI old env variables as were stated in the old subject, in order to pass terst no6. The addtional env variables are in a separate block inside `_buildEnvp()` except `tmp["PATH_TRANSLATED"]` as it made more sense to me to be right below `tmp["PATH_INFO"]`. As it turns out, the env variable that actually made the difference was `REQUEST_URI` and `PATH_INFO` to be getting the full path