### PR TITLE
fixed head

### DIFF
--- a/src/static/StaticHandler.cpp
+++ b/src/static/StaticHandler.cpp
@@ -145,16 +145,19 @@ Response	StaticHandler::handleError(HttpStatus const& status)
 	resp.setContentType(_getMime("html"));
 
 	ErrorPages::const_iterator search = locErrorPages.find(status.getCode());
-	if (search != locErrorPages.end())
+	if (_routingDecision.getRequest().getMethod() != "HEAD")
 	{
-		std::string errorPath = search->second;
-		if (utils::isReadableFile(errorPath)) {
-			_finalPath = errorPath; //!\ final path updated
-			resp.setBody(utils::readFile(_finalPath));
-			return resp;
+		if (search != locErrorPages.end())
+		{
+			std::string errorPath = search->second;
+			if (utils::isReadableFile(errorPath)) {
+				_finalPath = errorPath; //!\ final path updated
+				resp.setBody(utils::readFile(_finalPath));
+				return resp;
+			}
 		}
+		resp.setBody(_errorPageHtml(status));
 	}
-	resp.setBody(_errorPageHtml(status));
 	return resp;
 }
 


### PR DESCRIPTION
Seems the HEAD test on tester, had the warning because even if it was a 405 error, we still returned the body of the error.

Fixed now, so in HEAD requests in case of errors, there will be no error body returned!

The test now passes correctly, without warnings.

`Test HEAD http://localhost:8080/`