### PR TITLE
Last fixes

### DIFF
--- a/inc/http/Response.hpp
+++ b/inc/http/Response.hpp
@@ -33,6 +33,7 @@ class Response
 	void		_parseRawResponse(std::string const&);
 	bool		_hasHeader(std::string const&) const;
 	std::string	_buildHeaders() const;
+	void		_handleSession(const Request& request);
 
 	public:
 
@@ -49,7 +50,7 @@ class Response
 		bool		isConnectionClose() const;
 
 		static Response	initCgiResponse(RoutingDecision const&, std::string const&, HostPortPair const&);
-		void			parseFromCgiOutput(std::string const&);
+		void			parseFromCgiOutput(std::string const&, const Request&);
 		void			parseHeadersFromCgiOutput(std::string const&);
 		CgiData*		transferCgiDataOwnership();
 
@@ -69,8 +70,6 @@ class Response
 		std::string const&				getServedFilePath() const;
 		bool							needsCgiExecution() const;
 		CgiData const*					getCgiData() const;
-
-		void							handleSession(const Request& request);
 
 		class RawException: public std::runtime_error {
 			public:

--- a/inc/static/StaticHandler.hpp
+++ b/inc/static/StaticHandler.hpp
@@ -21,9 +21,6 @@ class StaticHandler
 	static std::string	_builtinAutoindexHtml(RoutingDecision const&);
 	static std::string	_builtinErrorPageHtml(HttpStatus const&);
 	static std::string	_builtinWelcomePageHtml();
-	static Response		_writeFile(const std::string&, const std::string&, const Request&);
-	static Response		_appendToFile(const std::string&, const std::string&, const Request&);
-	static Response		_createFile(RoutingDecision const&);
 
 	static std::string	_getMime(std::string const&);
 	static std::string	_getMimeFromPath(std::string const&);

--- a/inc/static/StaticHandler.hpp
+++ b/inc/static/StaticHandler.hpp
@@ -21,6 +21,9 @@ class StaticHandler
 	static std::string	_builtinAutoindexHtml(RoutingDecision const&);
 	static std::string	_builtinErrorPageHtml(HttpStatus const&);
 	static std::string	_builtinWelcomePageHtml();
+	static Response		_writeFile(const std::string&, const std::string&, const Request&);
+	static Response		_appendToFile(const std::string&, const std::string&, const Request&);
+	static Response		_createFile(RoutingDecision const&);
 
 	static std::string	_getMime(std::string const&);
 	static std::string	_getMimeFromPath(std::string const&);

--- a/inc/utils/utils.hpp
+++ b/inc/utils/utils.hpp
@@ -56,6 +56,7 @@ namespace utils {
 	std::string	formatDate(time_t, const std::string&);
 	std::string extractHostname(UniqHeaders const&);
 	std::pair<size_t, size_t>	headersBodySeparatorPos(std::string const&);
+	std::string	getParentDirectory(const std::string&);
 
 }
 

--- a/src/cgi/CgiHandler.cpp
+++ b/src/cgi/CgiHandler.cpp
@@ -313,8 +313,7 @@ void CgiHandler::checkCompletion()
 				try {
 					Log::dev("debug", "CGI output:\n" + PrintableString(Log::excerpt(Log::EXCERPT_SIZE, ctx->getOutput())));
 					Response resp;
-					resp.parseFromCgiOutput(ctx->getOutput());
-					resp.handleSession(ctx->getRequest());
+					resp.parseFromCgiOutput(ctx->getOutput(), ctx->getRequest());
 					_network->prepareResponseSend(ctx->getClientFd(), resp);
 					_network->epollControl(ctx->getClientFd(), EPOLL_CTL_MOD, EPOLLOUT, "CGI response ready");
 				} catch (std::exception& e) {

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -112,7 +112,7 @@ Response	Response::initCgiResponse(RoutingDecision const& rd, std::string const&
  *
  * Throws Response::RawException if headers are malformed or missing Content-Type.
  */
-void Response::parseFromCgiOutput(std::string const& cgiOutput)
+void Response::parseFromCgiOutput(std::string const& cgiOutput, const Request& request)
 {
 	if (cgiOutput.empty())
 		throw RawException("CGI output is empty");
@@ -130,6 +130,9 @@ void Response::parseFromCgiOutput(std::string const& cgiOutput)
 
 	// Set body
 	setBodyAndContentLength(bodyPart);
+
+	// Handle session
+	_handleSession(request);
 }
 
 void Response::parseHeadersFromCgiOutput(std::string const& headersOnly)
@@ -162,21 +165,16 @@ void Response::parseHeadersFromCgiOutput(std::string const& headersOnly)
 			value = value.substr(start);
 		std::string lname = utils::toLowerCase(key);
 		// Check if it has session headers
-		if (lname == "x-webserv-create-session") {
+		if (lname == "x-webserv-create-session")
 			_pendingSessionUsername = value;
-			continue;
-		}
-		if (lname == "x-webserv-destroy-session") {
+		else if (lname == "x-webserv-destroy-session")
 			_expireSession = true;
-			continue;
-		}
 		// Check if it's the Status header
-		if (lname == "status") {
+		else if (lname == "status") {
 			std::istringstream statusStream(value);
 			statusStream >> statusCode;
-		} else {
+		} else 
 			setHeader(key, value);
-		}
 	}
 
 	// Vérifier qu'on a bien Content-Type
@@ -207,7 +205,7 @@ CgiData*	Response::transferCgiDataOwnership()
  *   destroys the current session and expires the client's cookie.
  * 
  */
-void	Response::handleSession(const Request& request)
+void	Response::_handleSession(const Request& request)
 {
 	SessionManager& sm = SessionManager::getInstance();
 

--- a/src/static/StaticHandler.cpp
+++ b/src/static/StaticHandler.cpp
@@ -80,21 +80,19 @@ Response	StaticHandler::del(RoutingDecision const& rd)
 		return error("internal_server_error", rd);
 }
 
-/**
- * Handle POST requests to static files.
- */
 Response StaticHandler::post(RoutingDecision const& rd)
 {
-	std::string const& finalPath = rd.getFinalPath();
 	const Request& req = rd.getRequest();
+	std::string const& finalPath = rd.getFinalPath();
 
-	if (utils::isAccessibleDirectory(finalPath) || !utils::fileExists(finalPath))
-		return _createFile(rd);
-	else {
-		if (access(finalPath.c_str(), W_OK) != 0)
-			return error("forbidden", rd);
-		return _appendToFile(finalPath, req.getBody(), req);
+	bool isVirtualEndpoint = !utils::fileExists(finalPath) && !utils::isAccessibleDirectory(finalPath);
+	if (isVirtualEndpoint) {
+		Response resp;
+		resp.setStatus(HttpStatus("no_content"));
+		resp.setConnectionFromRequest(req);
+		return resp;
 	}
+	return error("method_not_allowed", rd);
 }
 
 Response	StaticHandler::head(RoutingDecision const& rd)
@@ -109,14 +107,37 @@ Response	StaticHandler::put(RoutingDecision const& rd)
 	Request const& req = rd.getRequest();
 	std::string const& finalPath = rd.getFinalPath();
 
-	if (utils::isAccessibleDirectory(finalPath))
+	std::string directory = finalPath;
+	if (utils::isAccessibleDirectory(finalPath)) {
+        return error("forbidden", rd);
+	} else {
+		size_t lastSlash = finalPath.find_last_of('/');
+		if (lastSlash != std::string::npos)
+			directory = finalPath.substr(0, lastSlash);
+    }
+	if (directory.empty())
+		directory = "/";
+	if (!utils::isWritableDirectory(directory))
 		return error("forbidden", rd);
-	std::string parentDir = utils::getParentDirectory(finalPath);
-	if (!utils::isWritableDirectory(parentDir))
-		return error("forbidden", rd);
-	if (utils::fileExists(finalPath) && access(finalPath.c_str(), W_OK) != 0)
-		return error("forbidden", rd);
-	return _writeFile(finalPath, req.getBody(), req);
+	std::string const& body = req.getBody();
+	bool fileExists = utils::fileExists(finalPath);
+	std::ofstream file(finalPath.c_str(), std::ios::binary);
+	if (!file.is_open())
+		return error("internal_server_error", rd);
+	file.write(body.c_str(), body.size());
+	file.close();
+
+	Response resp;
+    if (fileExists) {
+        resp.setStatus(HttpStatus("ok"));
+		resp.setHeader("Content-Location", req.getPath());
+	} else {
+		resp.setStatus(HttpStatus("created"));
+		resp.setHeader("Location", req.getPath());
+	}
+	resp.setServedFilePath(finalPath);
+	resp.setConnectionFromRequest(req);
+	return resp;
 }
 
 /**
@@ -193,84 +214,6 @@ Response	StaticHandler::builtinError(std::string const& errorSlug, std::string c
 		resp.setBodyAndContentLength(errorBody);
 	else
 		resp.setHeader("Content-Length", utils::str(errorBody.size()));
-	return resp;
-}
-
-/**
- * Write or replace a file with given content.
- * Used by PUT and POST (create) operations.
- */
-Response	StaticHandler::_writeFile(const std::string& path, const std::string& content, const Request& req)
-{
-	std::ofstream file(path.c_str(), std::ios::binary);
-	if (!file.is_open())
-		 return error("internal_server_error", req, ErrorPages());
-	file.write(content.c_str(), content.size());
-	file.close();
-	Response resp;
-	bool fileExists = utils::fileExists(path);
-    if (fileExists) {
-        resp.setStatus(HttpStatus("ok"));
-		resp.setHeader("Content-Location", req.getPath());
-	} else {
-		resp.setStatus(HttpStatus("created"));
-		resp.setHeader("Location", req.getPath());
-	}
-	resp.setServedFilePath(path);
-	resp.setConnectionFromRequest(req);
-	return resp;
-}
-
-/**
- * Append content to an existing file.
- * Used by POST to existing files.
- */
-Response	StaticHandler::_appendToFile(const std::string& path, const std::string& content, const Request& request)
-{
-	std::ofstream file(path.c_str(), std::ios::binary | std::ios::app);
-	if (!file.is_open())
-		return error("internal_server_error", request, ErrorPages());
-	file.write(content.c_str(), content.size());
-	file.close();
-	Response resp;
-	resp.setStatus(HttpStatus("ok"));
-	resp.setServedFilePath(path);
-	resp.setConnectionFromRequest(request);
-	return resp;
-}
-
-/**
- * Create a new file with POST.
- * 
- * For directories: Creates file with unique name inside directory
- * For non-existent paths: Creates file at exact path
- */
-Response	StaticHandler::_createFile(RoutingDecision const& rd)
-{
-	const Request& req = rd.getRequest();
-	std::string const& finalPath = rd.getFinalPath();
-
-	bool isDirectory = utils::isAccessibleDirectory(finalPath);
-	std::string filePath;
-	std::string locationHeader;
-	if (isDirectory) {
-		std::string filename = "upload_" + utils::str(time(NULL)) + ".post";
-		filePath = utils::pathsJoin(finalPath, filename);
-		locationHeader = req.getPath();
-		if (!locationHeader.empty() && locationHeader[locationHeader.size() - 1] != '/')
-			locationHeader += '/';
-		locationHeader += filename;
-	}
-	else {
-		std::string parentDir = utils::getParentDirectory(finalPath);
-		if (!utils::isWritableDirectory(parentDir))
-			return error("forbidden", rd);
-		filePath = finalPath;
-		locationHeader = req.getPath();
-	}
-	Response resp = _writeFile(filePath, req.getBody(), req);
-	if (resp.getStatus().getSlug() == "created")
-		resp.setHeader("Location", locationHeader);
 	return resp;
 }
 

--- a/src/static/StaticHandler.cpp
+++ b/src/static/StaticHandler.cpp
@@ -81,10 +81,20 @@ Response	StaticHandler::del(RoutingDecision const& rd)
 }
 
 /**
- * Simply return an error (POST method not allowed on a static file).
+ * Handle POST requests to static files.
  */
-Response StaticHandler::post(RoutingDecision const& rd) {
-	return error("method_not_allowed", rd);
+Response StaticHandler::post(RoutingDecision const& rd)
+{
+	std::string const& finalPath = rd.getFinalPath();
+	const Request& req = rd.getRequest();
+
+	if (utils::isAccessibleDirectory(finalPath) || !utils::fileExists(finalPath))
+		return _createFile(rd);
+	else {
+		if (access(finalPath.c_str(), W_OK) != 0)
+			return error("forbidden", rd);
+		return _appendToFile(finalPath, req.getBody(), req);
+	}
 }
 
 Response	StaticHandler::head(RoutingDecision const& rd)
@@ -99,37 +109,14 @@ Response	StaticHandler::put(RoutingDecision const& rd)
 	Request const& req = rd.getRequest();
 	std::string const& finalPath = rd.getFinalPath();
 
-	std::string directory = finalPath;
-	if (utils::isAccessibleDirectory(finalPath)) {
-        return error("forbidden", rd);
-	} else {
-		size_t lastSlash = finalPath.find_last_of('/');
-		if (lastSlash != std::string::npos)
-			directory = finalPath.substr(0, lastSlash);
-    }
-	if (directory.empty())
-		directory = "/";
-	if (!utils::isWritableDirectory(directory))
+	if (utils::isAccessibleDirectory(finalPath))
 		return error("forbidden", rd);
-	std::string const& body = req.getBody();
-	bool fileExists = utils::fileExists(finalPath);
-	std::ofstream file(finalPath.c_str(), std::ios::binary);
-	if (!file.is_open())
-		return error("internal_server_error", rd);
-	file.write(body.c_str(), body.size());
-	file.close();
-
-	Response resp;
-    if (fileExists) {
-        resp.setStatus(HttpStatus("ok"));
-		resp.setHeader("Content-Location", req.getPath());
-	} else {
-		resp.setStatus(HttpStatus("created"));
-		resp.setHeader("Location", req.getPath());
-	}
-	resp.setServedFilePath(finalPath);
-	resp.setConnectionFromRequest(req);
-	return resp;
+	std::string parentDir = utils::getParentDirectory(finalPath);
+	if (!utils::isWritableDirectory(parentDir))
+		return error("forbidden", rd);
+	if (utils::fileExists(finalPath) && access(finalPath.c_str(), W_OK) != 0)
+		return error("forbidden", rd);
+	return _writeFile(finalPath, req.getBody(), req);
 }
 
 /**
@@ -184,7 +171,9 @@ Response	StaticHandler::error(std::string const& errorSlug, Request const& req, 
 			return resp;
 		}
 	}
-	return builtinError(status.getSlug(), method);
+	Response resp = builtinError(status.getSlug(), method);
+	resp.setConnectionFromRequest(req);
+	return resp;
 }
 
 /**
@@ -204,7 +193,84 @@ Response	StaticHandler::builtinError(std::string const& errorSlug, std::string c
 		resp.setBodyAndContentLength(errorBody);
 	else
 		resp.setHeader("Content-Length", utils::str(errorBody.size()));
-	// TODO keep alive ?
+	return resp;
+}
+
+/**
+ * Write or replace a file with given content.
+ * Used by PUT and POST (create) operations.
+ */
+Response	StaticHandler::_writeFile(const std::string& path, const std::string& content, const Request& req)
+{
+	std::ofstream file(path.c_str(), std::ios::binary);
+	if (!file.is_open())
+		 return error("internal_server_error", req, ErrorPages());
+	file.write(content.c_str(), content.size());
+	file.close();
+	Response resp;
+	bool fileExists = utils::fileExists(path);
+    if (fileExists) {
+        resp.setStatus(HttpStatus("ok"));
+		resp.setHeader("Content-Location", req.getPath());
+	} else {
+		resp.setStatus(HttpStatus("created"));
+		resp.setHeader("Location", req.getPath());
+	}
+	resp.setServedFilePath(path);
+	resp.setConnectionFromRequest(req);
+	return resp;
+}
+
+/**
+ * Append content to an existing file.
+ * Used by POST to existing files.
+ */
+Response	StaticHandler::_appendToFile(const std::string& path, const std::string& content, const Request& request)
+{
+	std::ofstream file(path.c_str(), std::ios::binary | std::ios::app);
+	if (!file.is_open())
+		return error("internal_server_error", request, ErrorPages());
+	file.write(content.c_str(), content.size());
+	file.close();
+	Response resp;
+	resp.setStatus(HttpStatus("ok"));
+	resp.setServedFilePath(path);
+	resp.setConnectionFromRequest(request);
+	return resp;
+}
+
+/**
+ * Create a new file with POST.
+ * 
+ * For directories: Creates file with unique name inside directory
+ * For non-existent paths: Creates file at exact path
+ */
+Response	StaticHandler::_createFile(RoutingDecision const& rd)
+{
+	const Request& req = rd.getRequest();
+	std::string const& finalPath = rd.getFinalPath();
+
+	bool isDirectory = utils::isAccessibleDirectory(finalPath);
+	std::string filePath;
+	std::string locationHeader;
+	if (isDirectory) {
+		std::string filename = "upload_" + utils::str(time(NULL)) + ".post";
+		filePath = utils::pathsJoin(finalPath, filename);
+		locationHeader = req.getPath();
+		if (!locationHeader.empty() && locationHeader[locationHeader.size() - 1] != '/')
+			locationHeader += '/';
+		locationHeader += filename;
+	}
+	else {
+		std::string parentDir = utils::getParentDirectory(finalPath);
+		if (!utils::isWritableDirectory(parentDir))
+			return error("forbidden", rd);
+		filePath = finalPath;
+		locationHeader = req.getPath();
+	}
+	Response resp = _writeFile(filePath, req.getBody(), req);
+	if (resp.getStatus().getSlug() == "created")
+		resp.setHeader("Location", locationHeader);
 	return resp;
 }
 
@@ -306,7 +372,6 @@ std::string StaticHandler::_builtinErrorPageHtml(HttpStatus const& status)
 		"</html>"
 	);
 }
-
 
 // MIME
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -338,3 +338,16 @@ std::pair<size_t, size_t> utils::headersBodySeparatorPos(std::string const& rawR
 
 	return std::make_pair(std::string::npos, 0);
 }
+
+/**
+ * Helper to get parent directory from a path.
+ */
+std::string	utils::getParentDirectory(const std::string& path)
+{
+	size_t lastSlash = path.find_last_of('/');
+	if (lastSlash == std::string::npos)
+		return "/";
+	if (lastSlash == 0)
+		return "/"; // Root directory
+	return path.substr(0, lastSlash);
+}

--- a/tests/website/home.htm
+++ b/tests/website/home.htm
@@ -168,7 +168,7 @@
 			</tr><tr>
 				<td><code>GET</code></td>
 				<td><a href="http://localhost:8080/cgi/invalid-path.php" class="test-link">http://localhost:8080/cgi/invalid-path.php</a></td>
-				<td class="status-error">404</td>
+				<td class="status-error">500</td>
 				<td class="notes">Non-existent PHP file</td>
 			</tr><tr>
 				<td><code>GET</code></td>
@@ -211,7 +211,7 @@
 			</tr><tr>
 				<td><code>GET</code></td>
 				<td><a href="http://localhost:8080/cgi/invalid-path.py" class="test-link">http://localhost:8080/cgi/invalid-path.py</a></td>
-				<td class="status-error">404</td>
+				<td class="status-error">500</td>
 				<td class="notes">Non-existent Python file</td>
 			</tr><tr>
 				<td><code>GET</code></td>


### PR DESCRIPTION
- Made the header checks according to your commends inside `parseHeadersFromCgiOutput()`
- Removed` handleSession()` from CGIHandler and it's now called inside `Response::parseFromCgiOutput`. For that, I had to add the request object inside the method parameters, as ` handleSession()` needs to read the cookies from the request object.
- `StaticHandler::error` now correctly sets `resp.setConnectionFromRequest(req);` in all cases. We cannot handle this inside `StaticHandler::builtinError` as you asked, because this method doesn't have knowledge of the request object at all, as you say in your own notes "Sends back error before request parsing was done ".
- Fixed home.htm non existand script tests from Expected Result `404 `to `500`, because we removed these file checks from CGI, as CGI is apparently expected to behave like this.
- Added a check inside` StaticHandler::post` to check if it's a virtual endpoint inside the location block or not, if it is, it returns 204, if not, 405 as it should. The tester passes with it, and we move on. ( I consider that this is done in a "bad way", what I really check is if the file exists or not and call that a virtual endpoint + it will always return 204 in a location block that won't have cgi files and a random file name which is wrong.....)

-----------------------------------------------------------------------------------------------------------------------------------------------

Now, concerning these virtual endpoints I also talked about in Slack, is something we don't handle, we only handle folders/files in location blocks inside the path. But after very very careful consideration, I do think that that's what the tester is checking here : It never tells us to create a file/folder post_body, it actually tells us to use it like this inside the config file as a virtual endpoint, and it tests if we actually handle that. 
So think about it, see if we need to actually implement additional stuff, or just go with my fix inside POST (which is more like a patch not a fix, as this isn't technically handling virtual endpoints) and never think about it again....I don't know my brain is fried. Maybe what I am saying is bullshit, but I had a hunch that perhaps post_body isn't meant to be a file or folder when I asked you in Slack...So I made further research, but I am afraid that if I am right about this, it needs some modifications inisde locationblock/config and routing decision, so what do you think? It sounds like a LOT of overkill, the subject doesn't metnion this anywhere....

EDIT : It's now 3 am here, and I got really tire dof searching and thinking about this. I thought that maybe post_body could evne be the directory that the tester uses to store uploaded files? I don't know...I have found 0 posts about this test in Slack, and it's very weird that what, everybody had 0 issues in this test? Everyone handled this correctly + have implemented virutal endpoints? I doubt that...So bottom line : Do we stick to the implementation I made ? Because if an evaluator tries to test a similar location block that doesn't have a CGI file with a file that doesn't exist, it will return 204, do we want that ??  Maybe we should just take it out (only keep it for the test_42 version you're making now), always return 405 + fuck virtual endpoints, the subject never asked for that....