### PR TITLE
Ava fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ webserv
 webserv_dev
 log*
 tests/website/*.txt
+!tests/website/put_test.txt
 tests/*[0-9][gGmMkK][bB]

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CXX = c++
 
 CXXFLAGS := -Wall -Wextra -Werror -std=c++98
 
-VALGRIND = valgrind --leak-check=full --track-fds=yes
+VALGRIND = valgrind --track-origins=yes --leak-check=full --track-fds=yes
 
 # ------- CONFIG --------
 

--- a/inc/http/RequestParser.hpp
+++ b/inc/http/RequestParser.hpp
@@ -30,6 +30,7 @@ class RequestParser
 	static void			_extractScriptAndPathInfo(Request&, std::string const&);
 	static bool			_isValidVersion(std::string const&);
 	static bool			_isValidVersionNumber(std::string const&);
+	static bool			_hasDuplicateSingleHeaders(const AllHeaders&);
 	static bool			_isValidHeaderName(std::string const&);
 	static bool			_isValidHeaderValue(std::string const&);
 	static bool			_headersIndicateBody(Request const&);

--- a/src/http/Request.cpp
+++ b/src/http/Request.cpp
@@ -5,6 +5,7 @@ std::set<std::string>	Request::_existingMethods;
 
 Request::Request()
 : _status(HttpStatus())
+, _loggedBytes(0)
 {}
 
 Request::Request(const Request& other)
@@ -22,6 +23,7 @@ Request::Request(const Request& other)
 , _body(other._body)
 , _rawRequest(other._rawRequest)
 , _cookies(other._cookies)
+, _loggedBytes(other._loggedBytes)
 {}
 
 Request& Request::operator=(const Request& other)
@@ -41,6 +43,7 @@ Request& Request::operator=(const Request& other)
 		_body = other._body;
 		_rawRequest = other._rawRequest;
 		_cookies = other._cookies;
+		_loggedBytes = other._loggedBytes;
 	}
 	return (*this);
 }

--- a/src/http/RequestParser.cpp
+++ b/src/http/RequestParser.cpp
@@ -180,6 +180,8 @@ HttpStatus RequestParser::_parseHeaders(Request& request, std::string const& hea
 		if (result.getSlug() != "ok")
 			return result;
 	}
+//	if (_hasDuplicateSingleHeaders(request.getAllHeaders()))
+//		return HttpStatus("bad_request");
 	const std::vector<std::pair<std::string, std::string> >& allHeaders = request.getAllHeaders();
 	int hostHeaderCount = 0;
 	for (size_t i = 0; i < allHeaders.size(); ++i) {
@@ -433,6 +435,27 @@ bool	RequestParser::_isValidVersionNumber(std::string const& numStr)
 			return false;
 	return true;
 }
+
+/*bool	RequestParser::_hasDuplicateSingleHeaders(const AllHeaders& headers)
+{
+	int	hostCount = 0;
+	int contentTypeCount = 0;
+	int contentLengthCount = 0;
+	int connectionCount = 0;
+        
+	for (size_t i = 0; i < headers.size(); ++i) {
+		std::string name = utils::toLowerCase(headers[i].first);    
+		if (name == "host")
+			hostCount++;
+		else if (name == "content-type")
+			contentTypeCount++;
+		else if (name == "content-length")
+			contentLengthCount++;
+		else if (name == "connection")
+			connectionCount++;
+	}
+	return (hostCount > 1 || contentTypeCount > 1 || contentLengthCount > 1 || connectionCount > 1);
+}*/
 
 bool	RequestParser::_isValidHeaderName(std::string const& name)
 {

--- a/src/http/RequestParser.cpp
+++ b/src/http/RequestParser.cpp
@@ -72,6 +72,8 @@ bool	RequestParser::isRawRequestComplete(Request const& req)
 
 		// Compare to the actual body length
 		size_t bodyLength = rawRequest.size() - bodyStartPos;
+		if (bodyLength != contentLength)
+			return true;
 		return (bodyLength >= contentLength);
 	}
 	return true;

--- a/src/http/RequestParser.cpp
+++ b/src/http/RequestParser.cpp
@@ -180,8 +180,8 @@ HttpStatus RequestParser::_parseHeaders(Request& request, std::string const& hea
 		if (result.getSlug() != "ok")
 			return result;
 	}
-//	if (_hasDuplicateSingleHeaders(request.getAllHeaders()))
-//		return HttpStatus("bad_request");
+	if (_hasDuplicateSingleHeaders(request.getAllHeaders()))
+		return HttpStatus("bad_request");
 	const std::vector<std::pair<std::string, std::string> >& allHeaders = request.getAllHeaders();
 	int hostHeaderCount = 0;
 	for (size_t i = 0; i < allHeaders.size(); ++i) {
@@ -436,7 +436,7 @@ bool	RequestParser::_isValidVersionNumber(std::string const& numStr)
 	return true;
 }
 
-/*bool	RequestParser::_hasDuplicateSingleHeaders(const AllHeaders& headers)
+bool	RequestParser::_hasDuplicateSingleHeaders(const AllHeaders& headers)
 {
 	int	hostCount = 0;
 	int contentTypeCount = 0;
@@ -455,7 +455,7 @@ bool	RequestParser::_isValidVersionNumber(std::string const& numStr)
 			connectionCount++;
 	}
 	return (hostCount > 1 || contentTypeCount > 1 || contentLengthCount > 1 || connectionCount > 1);
-}*/
+}
 
 bool	RequestParser::_isValidHeaderName(std::string const& name)
 {

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -284,13 +284,15 @@ std::string Response::_buildHeaders() const
 		headerStream << "Cache-Control: " << _headers.find("cache-control")->second << "\r\n";
 	if (_headers.find("content-disposition") != _headers.end())
 		headerStream << "Content-Disposition: " << _headers.find("content-disposition")->second << "\r\n";
+	if (_headers.find("content-location") != _headers.end())
+		headerStream << "Content-Location: " << _headers.find("content-location")->second << "\r\n";
 	for (UniqHeaders::const_iterator it = _headers.begin();
 		it != _headers.end(); ++it)
 		{
 			std::string const& key = it->first;
 			if (key != "server" && key != "date" && key != "content-type" &&
-				key != "content-length" && key != "connection" &&
-				key != "location" && key != "cache-control" && key != "content-disposition")
+				key != "content-length" && key != "connection" && key != "location" &&
+				key != "cache-control" && key != "content-disposition" && key != "content-location")
 					headerStream << key << ": " << it->second << "\r\n";
 		}
 	return headerStream.str();

--- a/src/static/StaticHandler.cpp
+++ b/src/static/StaticHandler.cpp
@@ -65,8 +65,10 @@ Response	StaticHandler::del(RoutingDecision const& rd)
 
 	if (!utils::fileExists(finalPath))
 		return error("not_found", rd);
-	std::string directoryPath = finalPath.substr(0, finalPath.find_last_of('/'));
-	if (access(directoryPath.c_str(), W_OK) != 0)
+	if (utils::isAccessibleDirectory(finalPath))
+		return error("forbidden", rd);
+	std::string directoryPath = utils::getParentDirectory(finalPath);
+	if (!utils::isWritableDirectory(directoryPath))
 		return error("forbidden", rd);
 	if (std::remove(finalPath.c_str()) == 0)
 	{

--- a/src/static/StaticHandler.cpp
+++ b/src/static/StaticHandler.cpp
@@ -58,7 +58,7 @@ Response	StaticHandler::get(RoutingDecision const& rd)
 	return error("not_found", rd);
 }
 
-Response	StaticHandler::del(RoutingDecision const& rd)
+Response	StaticHandler::del(RoutingDecision const& rd)  
 {
 	std::string const& finalPath = rd.getFinalPath();
 	Request const& req = rd.getRequest();
@@ -154,7 +154,8 @@ Response	StaticHandler::_serveFile(std::string const& filePath, RoutingDecision 
 	Response resp;
 	resp.setStatus(HttpStatus("ok"));
 	resp.setHeader("Content-Type", _getMimeFromPath(filePath));
-	resp.setHeader("Content-Disposition", "inline; filename=\"" + utils::getFileName(filePath) + "\"");
+	if (_getMimeFromPath(filePath) == "application/octet-stream")
+		resp.setHeader("Content-Disposition", "inline; filename=\"" + utils::getFileName(filePath) + "\"");
 	resp.setBodyAndContentLength(content);
 	resp.setServedFilePath(filePath);
 	resp.setConnectionFromRequest(rd.getRequest());

--- a/tests/config/webserv.config
+++ b/tests/config/webserv.config
@@ -7,7 +7,7 @@ server {
 
 	location / {
 		index home.htm;
-		allowed_methods GET HEAD PUT;
+		allowed_methods GET HEAD PUT DELETE;
 	}
 
 	location /index {

--- a/tests/website/home.htm
+++ b/tests/website/home.htm
@@ -78,12 +78,18 @@
 				<td><code>PUT</code></td>
 				<td><code>curl -X PUT http://localhost:8080/put_test.txt -d "new content"</code></td>
 				<td class="status-ok">200</td>
-				<td class="notes">Demo file for <code>PUT</code> testing</td>
+				<td class="notes">Test <code>PUT</code> in an existing file</td>
 			</tr><tr>
 				<td><code>PUT</code></td>
 				<td><code>curl -X PUT http://localhost:8080/new_file.txt -d "your content"</code></td>
 				<td class="status-ok">201</td>
-				<td class="notes">Create any new file</td>
+				<td class="notes">Create (upload) any new file</td>
+			</tr>
+			</tr><tr>
+				<td><code>PUT</code> (image)</td>
+				<td><code>curl -X PUT http://localhost:8080/test_image.jpg --data-binary @/tmp/test_image.jpg</code></td>
+				<td class="status-ok">201</td>
+				<td class="notes">First do : <code>wget https://picsum.photos/200/300.jpg -O /tmp/test_image.jpg</code></td>
 			</tr>
 			</tr><tr>
 				<td><code>HEAD</code></td>

--- a/tests/website/home.htm
+++ b/tests/website/home.htm
@@ -106,18 +106,6 @@
 				<td class="status-ok">204</td>
 				<td class="notes">Deletes the test file</td>
 			</tr>
-			</tr><tr>
-				<td><code>DELETE</code></td>
-				<td><code>curl -X DELETE http://localhost:8080/nonexistent.txt</code></td>
-				<td class="status-error">404</td>
-				<td class="notes">File not found to delete</td>
-			</tr>
-			</tr><tr>
-				<td><code>DELETE</code></td>
-				<td><code>curl -X DELETE http://localhost:8080/read_only/test.txt</code></td>
-				<td class="status-error">403</td>
-				<td class="notes">No permission to delete the file</td>
-			</tr>
 
 			<!-- Autoindex Tests -->
 			<tr class="category">
@@ -152,6 +140,31 @@
 				<td><a href="http://localhost:8080/autoindex/off/invalid" class="test-link">http://localhost:8080/autoindex/off/invalid</a></td>
 				<td class="status-error">404</td>
 				<td class="notes">Custom 404 page</td>
+			</tr>
+			</tr><tr>
+				<td><code>PUT</code></td>
+				<td><code>curl -X PUT http://localhost:8080/read_only/ -d "test content"</code></td>
+				<td class="status-error">403</td>
+				<td class="notes">Trying to write to a directory path</td>
+			</tr>
+			</tr>
+			</tr><tr>
+				<td><code>PUT</code></td>
+				<td><code>curl -X PUT http://localhost:8080/read_only/new_file.txt -d "your content"</code></td>
+				<td class="status-error">403</td>
+				<td class="notes">Trying to upload to a read only folder</td>
+			</tr>
+			</tr><tr>
+				<td><code>DELETE</code></td>
+				<td><code>curl -X DELETE http://localhost:8080/nonexistent.txt</code></td>
+				<td class="status-error">404</td>
+				<td class="notes">File not found to delete</td>
+			</tr>
+			</tr><tr>
+				<td><code>DELETE</code></td>
+				<td><code>curl -X DELETE http://localhost:8080/read_only/test.txt</code></td>
+				<td class="status-error">403</td>
+				<td class="notes">No permission to delete the file</td>
 			</tr>
 
 			<!-- Redirection Tests -->

--- a/tests/website/home.htm
+++ b/tests/website/home.htm
@@ -76,20 +76,38 @@
 				<td class="notes">Browser downloads file</td>
 			</tr><tr>
 				<td><code>PUT</code></td>
-				<td><code>curl -X PUT http://localhost:8080/put-demo.txt -d "new content"</code></td>
+				<td><code>curl -X PUT http://localhost:8080/put_test.txt -d "new content"</code></td>
 				<td class="status-ok">200</td>
 				<td class="notes">Demo file for <code>PUT</code> testing</td>
 			</tr><tr>
 				<td><code>PUT</code></td>
-				<td><code>curl -X PUT http://localhost:8080/your-new-file.txt -d "your content"</code></td>
+				<td><code>curl -X PUT http://localhost:8080/new_file.txt -d "your content"</code></td>
 				<td class="status-ok">201</td>
 				<td class="notes">Create any new file</td>
 			</tr>
 			</tr><tr>
 				<td><code>HEAD</code></td>
-				<td><code>curl -I http://localhost:8080/put-demo.txt</code></td>
+				<td><code>curl -I http://localhost:8080/put_test.txt</code></td>
 				<td class="status-ok">200</td>
 				<td class="notes"><code>HEAD</code> request (headers only, no body)</td>
+			</tr>
+			</tr><tr>
+				<td><code>DELETE</code></td>
+				<td><code>curl -X DELETE http://localhost:8080/put_test.txt</code></td>
+				<td class="status-ok">204</td>
+				<td class="notes">Deletes the test file</td>
+			</tr>
+			</tr><tr>
+				<td><code>DELETE</code></td>
+				<td><code>curl -X DELETE http://localhost:8080/nonexistent.txt</code></td>
+				<td class="status-error">404</td>
+				<td class="notes">File not found to delete</td>
+			</tr>
+			</tr><tr>
+				<td><code>DELETE</code></td>
+				<td><code>curl -X DELETE http://localhost:8080/read_only/test.txt</code></td>
+				<td class="status-error">403</td>
+				<td class="notes">No permission to delete the file</td>
 			</tr>
 
 			<!-- Autoindex Tests -->

--- a/tests/website/home.htm
+++ b/tests/website/home.htm
@@ -26,7 +26,10 @@
 			</ul>
 		</div>
 		<div class="highlight-box">
-			<h2>Charge testing</h2>
+			<h2>Raw Request manual testing</h2>
+			<p>Eg with netcat <code>printf "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n" | nc localhost 8080</code></p>
+			<p>Eg with curl <code>curl -v http://localhost:8080/</code></p>
+			<h2>Siege testing</h2>
 			<p><code>sudo apt install siege</code></p>
 			<ol>
 				<li>

--- a/tests/website/put_test.txt
+++ b/tests/website/put_test.txt
@@ -1,0 +1,1 @@
+old content

--- a/tests/website/read_only/test.txt
+++ b/tests/website/read_only/test.txt
@@ -1,0 +1,1 @@
+can it be deleted?


### PR DESCRIPTION
Last moment issues that I found and fixed :

- In case of `PUT` and the uploading of an existing file, now the `Content-Location` header is displayed in the prompt title-case correctly, and not all lowercase.
- Added safety inside `StaticHandler::del()` not to be able to delete folders, only files.
- Made `Content-Disposition` to appear only in case the file has no extension or unknown extensions, so it doesn't appear in every single `GET` request. As I saw it's not a really standard header.
- Added a check where Content-type, Connection and Content-length headers should exist only once inside a raw request, just like the Host header. Any other header will be treated as random (same as Cookies) and the values of them can be combined. (we cannot possibly handle every header in existence but at least the most standard ones)
- Fixed a bug inside `RequestParser::isRawRequestComplete`, in any case of malformed raw requests with content-length the server just hang indefintely, as it always returned false in case this isn't true `bodyLength >= contentLength`.
- Fixed vaglrind errors, the `loggedBytes` attribute was never initialized inside the contructors in Request.
- Added `--track-origins=yes` inside the valgrind rule in Makefile, else I would never find the issue.

For testing reasons and to make the evaluation easier an faster, I added more tests inside `home.htm `:

- `DELETE `tests (also in errors)
- For `PUT` : emphasizing that by creating a file, means upload, added one more test to show that it works for images too + isntructions how to do it quickly + easy ( by getting a random image from a site called picsum, lol) + also added error tests 
- Added instructions for raw request manual testing

So inside` /website`, I added :
- A folder called `read_only `-> this is to show that if you try to delete a file there or with PUT to create a file, it won't happen, the folder has 555 permissions on purpose to demonstrate that.
-  A file called `put_test.txt ` It has to be there already, so when someone tries to test PUT (first PUT test we have) with the same file again, they can see 200, not 201 as if it's being created for the first time. Later on with the delete tests the evaluator will delete that file anyway so it will follow a natural flow : existing file gets overriden with new content -> then tested with HEAD to show only headers but not the body -> then it can be deleted in the next test

--------------------------------------------------------------------------------------------------------------------------------------------

Potential issue found from the eval sheet from Daniel :

Inside, `Network::_continuePendingSend` we only chekc for -1, but we don't also check in case it's 0 bytes what's happening

```
	if (bytesSent < 0) {
		// Sending error -> Disconnect client
		Log::prod("error", "Send failed for fd " + Log::hl(clientFd) + " during continued send");
		_disconnectClient(clientFd);
		return;
	}
```