### PR TITLE
Ava fixes2

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,4 @@ make
 - https://http.dev/400
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/
 - https://stackoverflow.com/
+- https://github.com/nginx/nginx

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ make
 
 - https://www.rfc-editor.org/rfc/rfc9112.html
 - https://www.rfc-editor.org/rfc/rfc9110
+- https://www.rfc-editor.org/rfc/rfc3875.html#section-4.1.1
 - https://en.wikipedia.org/wiki/HTTP
 - https://http.dev/400
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/
+- https://stackoverflow.com/

--- a/inc/cgi/CgiData.hpp
+++ b/inc/cgi/CgiData.hpp
@@ -14,6 +14,7 @@ class CgiData
 	std::string			_executor;
 	Request const&		_request; // non-owning
 	ErrorPages const&	_errorPages; // non-owning
+	std::string			_remoteAddr;
 
 	// Storage for execve (need to stay valid during execution)
 	std::vector<std::string>	_envStorage;	// Persistant storage for environment strings
@@ -34,7 +35,7 @@ class CgiData
 	public:
 
 		CgiData(CgiData const&);
-		CgiData(Request const&, LocationBlock const&, std::string const&, HostPortPair const&);
+		CgiData(Request const&, LocationBlock const&, std::string const&, HostPortPair const&, std::string const&);
 		~CgiData();
 
 		bool				isValid() const;

--- a/inc/cgi/CgiData.hpp
+++ b/inc/cgi/CgiData.hpp
@@ -7,9 +7,12 @@
 /**
  * Holds all data needed for CGI execution.
  *
- * Contains both owned data (_scriptName, _extension, etc.) and 
- * non-owning references (_request, _errorPages).
- * 
+ * Non-Value type class (it contains non-owning references: _request, _errorPages):
+ * - Copy-constructible only (for ownership transfer)
+ * - Not default-constructible (requires valid Request reference)
+ * - Not assignable (references cannot be reassigned)
+ *
+ * Intended usage: Create once, transfer ownership via copy, never reassign.
  */
 class CgiData
 {
@@ -35,12 +38,13 @@ class CgiData
 
 	static std::string	_headerToEnvVar(std::string const&);
 
-	CgiData();
-	CgiData&	operator=(CgiData const&);
+	// Forbidden
+	CgiData(); // Cannot init references
+	CgiData&	operator=(CgiData const&); // Cannot reassign references
 
 	public:
 
-		CgiData(CgiData const&);
+		CgiData(CgiData const&); // Allowed: for ownership transfer
 		CgiData(Request const&, LocationBlock const&, std::string const&, HostPortPair const&, std::string const&);
 		~CgiData();
 

--- a/inc/cgi/CgiData.hpp
+++ b/inc/cgi/CgiData.hpp
@@ -4,7 +4,14 @@
 #include "config/LocationBlock.hpp"
 #include "config/HostPortPair.hpp"
 
-// TODO canonical class verification + justification message
+/**
+ * Holds all data needed for CGI execution.
+ *
+ * Contains both owned data (_scriptName, _extension, etc.) and 
+ * non-owning references (_request, _errorPages).
+ * 
+ * Value-type class: copyable, assignable, holds its own data.
+ */
 class CgiData
 {
 	bool	_isValid;

--- a/inc/cgi/CgiData.hpp
+++ b/inc/cgi/CgiData.hpp
@@ -10,7 +10,6 @@
  * Contains both owned data (_scriptName, _extension, etc.) and 
  * non-owning references (_request, _errorPages).
  * 
- * Value-type class: copyable, assignable, holds its own data.
  */
 class CgiData
 {

--- a/inc/cgi/CgiHandler.hpp
+++ b/inc/cgi/CgiHandler.hpp
@@ -7,7 +7,13 @@ class Network;
 #include "utils/Const.hpp"
 #include <sys/wait.h>
 
-// TODO canonical class verification + justification message
+/**
+ * Manages CGI process execution and I/O.
+ *
+ * Manages lifecycle of CGI processes and their file descriptors.
+ * Single instance per Network instance.
+ * Entity-type class: owns resources (processes, pipes), non-copyable.
+ */
 class CgiHandler
 {
 	static size_t const	_READ_BUFFER_SIZE;

--- a/inc/http/RequestParser.hpp
+++ b/inc/http/RequestParser.hpp
@@ -32,7 +32,7 @@ class RequestParser
 	static bool			_isValidVersionNumber(std::string const&);
 	static bool			_hasDuplicateSingleHeaders(const AllHeaders&);
 	static bool			_isValidHeaderName(std::string const&);
-	static bool			_isValidHeaderValue(std::string const&);
+	static bool			_isValidHeaderValue(std::string const&, std::string const&);
 	static bool			_headersIndicateBody(Request const&);
 	static bool			_isValidContentType(std::string const&);
 	static bool			_isValidContentLength(std::string const&);

--- a/inc/http/Response.hpp
+++ b/inc/http/Response.hpp
@@ -49,7 +49,7 @@ class Response
 		void		clearBodyForHead();
 		bool		isConnectionClose() const;
 
-		static Response	initCgiResponse(RoutingDecision const&, std::string const&, HostPortPair const&);
+		static Response	initCgiResponse(RoutingDecision const&, std::string const&, HostPortPair const&, std::string const&);
 		void			parseFromCgiOutput(std::string const&, const Request&);
 		void			parseHeadersFromCgiOutput(std::string const&);
 		CgiData*		transferCgiDataOwnership();

--- a/inc/network/Client.hpp
+++ b/inc/network/Client.hpp
@@ -5,7 +5,12 @@
 #include "http/Response.hpp"
 class Network;
 
-// TODO calss message with canonical explanation
+/**
+ * Represents a single client connection with its state.
+ *
+ * Tracks connection lifecycle, buffers requests/responses, and manages I/O timing.
+ * Entity-type class: not copyable or assignable; owned and cleaned up by Network.
+ */
 class Client
 {
 	int			_fd;
@@ -25,7 +30,6 @@ class Client
 
 	void	_resetForNextRequest();
 
-	// TODO canonical ?
 	Client(Client const&);
 	Client&	operator=(Client const&);
 

--- a/inc/network/Client.hpp
+++ b/inc/network/Client.hpp
@@ -18,6 +18,8 @@ class Client
 	size_t		_responseSendPos;
 	bool		_shouldCloseAfterResponse;
 
+	std::string	_remoteAddr;
+
 	// TODO canonical ?
 	Client(Client const&);
 	Client&	operator=(Client const&);
@@ -43,7 +45,9 @@ class Client
 		std::string const&	getResponse() const;
 		size_t const&		getResponseSendPos() const;
 		bool			shouldCloseAfterResponse() const;
+		std::string const&	getRemoteAddr() const;
 
+		void	setRemoteAddr(const std::string&);
 
 };
 

--- a/inc/network/Socket.hpp
+++ b/inc/network/Socket.hpp
@@ -34,7 +34,7 @@ class Socket
 
 		void	safeBind();
 		void	safeListen();
-		int		createNewClientSocket();
+		int		createNewClientSocket(std::string& clientIpOut);
 
 		HostPortPair const&	getListenDirective() const;
 		int					getFd() const;

--- a/inc/router/Router.hpp
+++ b/inc/router/Router.hpp
@@ -15,7 +15,7 @@
 class Router
 {
 	static Response	_handleRedirectionDecision(RoutingDecision const&);
-	static Response	_handleCgiDecision(RoutingDecision const&, HostPortPair const&);
+	static Response	_handleCgiDecision(RoutingDecision const&, HostPortPair const&, std::string const&);
 	static Response	_handleStaticDecision(RoutingDecision const&);
 
 	// Not instantiable
@@ -26,7 +26,7 @@ class Router
 
 	public:
 
-		static Response 	dispatchRequest(Config const&, Request const&, HostPortPair const&);
+		static Response 	dispatchRequest(Config const&, Request const&, HostPortPair const&, std::string const&);
 };
 
 #endif

--- a/inc/session/Session.hpp
+++ b/inc/session/Session.hpp
@@ -5,14 +5,15 @@
 # include <ctime>
 # include <map>
 /**
- * Represents a single user session with identity, timing, and custom data
+ * Represents a single user session with identity and timing.
  * 
  * Each Session object contains:
  * - Private attributes: session ID (_sessionId) and username (_username)
  * - Creation and last activity timestamps for expiration tracking
  * - Logic to determine session validity based on timeout
  * 
- * This class is a data container for individual user sessions!
+ * Simple data container for session information.
+ * Value-type class: copyable, assignable, holds its own data.
  */
 
 class Session

--- a/inc/session/SessionManager.hpp
+++ b/inc/session/SessionManager.hpp
@@ -13,7 +13,7 @@
  * - Maintains collection of all active Session objects
  * - Performs automatic cleanup of expired sessions
  *
- * Only one instance manages all sessions across the application.
+ * Singleton-type class: not instantiable externally; single instance via getInstance().
  */
 
 class SessionManager

--- a/inc/utils/Const.hpp
+++ b/inc/utils/Const.hpp
@@ -13,7 +13,7 @@
 # define UBUNTU_TESTER 0
 #endif
 
-#define PRINT_DEBUG 0
+#define PRINT_DEBUG 1
 #define CGI_ENABLED 1
 
 class Const

--- a/inc/utils/Const.hpp
+++ b/inc/utils/Const.hpp
@@ -13,7 +13,7 @@
 # define UBUNTU_TESTER 0
 #endif
 
-#define PRINT_DEBUG 1
+#define PRINT_DEBUG 0
 #define CGI_ENABLED 1
 
 class Const

--- a/inc/utils/utils.hpp
+++ b/inc/utils/utils.hpp
@@ -7,6 +7,7 @@
 #include <stdexcept>
 #include <vector>
 #include <sys/stat.h>
+#include <netinet/in.h>
 #include <unistd.h>
 #include <fstream>
 #include <cerrno>
@@ -42,6 +43,7 @@ namespace utils {
 	size_t	hexToSizeT(std::string const&);
 	char	hexToChar(std::string const&);
 	std::string	toUpper(std::string const& s);
+	std::string	sockaddrInToIP(const struct sockaddr_in&);
 
 	std::string	readFile(std::string const&);
 	std::string	getFileName(std::string const&);

--- a/src/cgi/CgiData.cpp
+++ b/src/cgi/CgiData.cpp
@@ -1,4 +1,5 @@
 #include "cgi/CgiData.hpp"
+#include "network/Client.hpp"
 
 CgiData::CgiData(CgiData const& other)
 : _scriptName(other._scriptName)
@@ -6,6 +7,7 @@ CgiData::CgiData(CgiData const& other)
 , _executor(other._executor)
 , _request(other._request)
 , _errorPages(other._errorPages)
+, _remoteAddr(other._remoteAddr)
 , _envStorage(other._envStorage)
 , _argStorage(other._argStorage)
 {
@@ -13,12 +15,13 @@ CgiData::CgiData(CgiData const& other)
 	_setArgv();
 }
 
-CgiData::CgiData(Request const& req, LocationBlock const& loc, std::string const& scriptName, HostPortPair const& listeningOn)
+CgiData::CgiData(Request const& req, LocationBlock const& loc, std::string const& scriptName, HostPortPair const& listeningOn, std::string const& remoteAddr)
 : _scriptName(scriptName)
 , _extension(utils::getFileExtension(_scriptName))
 , _executor(loc.getCgiExecutor(_extension))
 , _request(req)
 , _errorPages(loc.getErrorPages())
+, _remoteAddr(remoteAddr)
 {
 	if (_extension.empty() || _executor.empty()) {
 		Log::prod("error", "CGI params: failed to initalise");
@@ -46,7 +49,9 @@ void	CgiData::_setEnvStorage(Request const& req, std::string const& locRoot, Hos
 	tmp["REQUEST_METHOD"] = req.getMethod();
 	tmp["SCRIPT_FILENAME"] = _scriptName; // absolute path
 	tmp["SCRIPT_NAME"] = req.getScriptName(); // relative path
-	tmp["PATH_INFO"] = req.getPath().empty() ? "/" : req.getPath(); //!\ full path for the ubuntu_tester to work
+	if (UBUNTU_TESTER)
+		tmp["PATH_INFO"] = req.getPath().empty() ? "/" : req.getPath(); //!\ full path for the ubuntu_tester to work
+	tmp["PATH_INFO"] = req.getPathInfo();
 	tmp["PATH_TRANSLATED"] = utils::pathsJoin(locRoot, tmp["PATH_INFO"]);
 	tmp["QUERY_STRING"] = req.getQueryString();
 	tmp["CONTENT_TYPE"] = req.getContentType();
@@ -56,9 +61,9 @@ void	CgiData::_setEnvStorage(Request const& req, std::string const& locRoot, Hos
 	tmp["GATEWAY_INTERFACE"] = "CGI/1.1";
 	tmp["SERVER_PROTOCOL"] = req.getVersion();
 	tmp["SERVER_SOFTWARE"] = Const::SERVER_SOFTWARE;
-	// Additional variables from old subject requirements to pass ubuntu_tester
-	tmp["REMOTE_ADDR"] = "0.0.0.0";  //!\ Not implemented (Client IP to be extracted by Network and pass it to Router)
-	tmp["REMOTE_IDENT"] = "";
+	tmp["REMOTE_ADDR"] = _remoteAddr;
+	tmp["REMOTE_HOST"] = _remoteAddr; // Same as REMOTE_ADDR/default
+	tmp["REMOTE_IDENT"] = ""; // Not implemented
 	tmp["AUTH_TYPE"] = ""; //!\ Auth not implemented
 	tmp["REMOTE_USER"] = ""; //!\ Auth not implemented
 	tmp["REQUEST_URI"] = req.getUri();

--- a/src/cgi/CgiData.cpp
+++ b/src/cgi/CgiData.cpp
@@ -51,7 +51,8 @@ void	CgiData::_setEnvStorage(Request const& req, std::string const& locRoot, Hos
 	tmp["SCRIPT_NAME"] = req.getScriptName(); // relative path
 	if (UBUNTU_TESTER)
 		tmp["PATH_INFO"] = req.getPath().empty() ? "/" : req.getPath(); //!\ full path for the ubuntu_tester to work
-	tmp["PATH_INFO"] = req.getPathInfo();
+	else
+		tmp["PATH_INFO"] = req.getPathInfo();
 	tmp["PATH_TRANSLATED"] = utils::pathsJoin(locRoot, tmp["PATH_INFO"]);
 	tmp["QUERY_STRING"] = req.getQueryString();
 	tmp["CONTENT_TYPE"] = req.getContentType();

--- a/src/http/RequestParser.cpp
+++ b/src/http/RequestParser.cpp
@@ -227,9 +227,9 @@ HttpStatus	RequestParser::_parseHeaderLine(Request& request, std::string const& 
 	if (!_isValidHeaderName(name))
 		return HttpStatus("bad_request");
 	value = utils::trim(value);
-	if (!_isValidHeaderValue(value))
-		return HttpStatus("bad_request");
 	std::string normalizedName = _normalizeHeaderName(name);
+	if (!_isValidHeaderValue(value, normalizedName))
+		return HttpStatus("bad_request");
 	if (normalizedName == "cookie") {
 		HttpStatus cookieStatus = _parseCookies(request, value);
 		if (cookieStatus.getSlug() != "ok")
@@ -260,7 +260,6 @@ HttpStatus	RequestParser::_parseHeaderLine(Request& request, std::string const& 
 HttpStatus	RequestParser::_parseCookies(Request& request, std::string const& cookieHeader)
 {
 	std::vector<std::string> cookies = utils::split(cookieHeader, ';');
-
 	for (size_t i = 0; i < cookies.size(); ++i)
 	{
 		std::string cookie = utils::trim(cookies[i]);
@@ -273,6 +272,8 @@ HttpStatus	RequestParser::_parseCookies(Request& request, std::string const& coo
 		{
 			std::string name = utils::trim(cookie.substr(0, equalPos));
 			std::string value = utils::trim(cookie.substr(equalPos + 1));
+			if (name.find_first_of(" \t") != std::string::npos)
+				return HttpStatus("bad_request");
 			if (value.length() >= 2 && value[0] == '"' && value[value.length() - 1] == '"')
 				value = value.substr(1, value.length() - 2);
 			if (!name.empty())
@@ -477,14 +478,7 @@ bool	RequestParser::_isValidHeaderName(std::string const& name)
 	return true;
 }
 
-bool	RequestParser::_headersIndicateBody(Request const& request)
-{
-	UniqHeaders const& headers = request.getUniqHeaders();
-	return (headers.find("content-length") != headers.end() ||
-			headers.find("transfer-encoding") != headers.end());
-}
-
-bool	RequestParser::_isValidHeaderValue(std::string const& value)
+bool	RequestParser::_isValidHeaderValue(std::string const& value, std::string const& headerName)
 {
 	for (size_t i = 0; i < value.length(); i++) {
 		if (value[i] == '\0')
@@ -492,7 +486,38 @@ bool	RequestParser::_isValidHeaderValue(std::string const& value)
 		if (value[i] < 0x20 || value[i] == 0x7F)
 			return false;
 	}
+	if (headerName == "host") {
+		if (value.find_first_of(" \t") != std::string::npos)
+			return false;
+		if (value.empty() || value[0] == ':')
+			return false;
+		size_t colon = value.find(':');
+		if (colon != std::string::npos) {
+			std::string port = value.substr(colon + 1);
+			if (port.empty())
+				return false;
+			for (size_t i = 0; i < port.length(); ++i) {
+				if (!std::isdigit(port[i]))
+					return false;
+			}
+			try {
+				size_t portNum = utils::toSizeT(port);
+				if (portNum < 1 || portNum > 65535)
+					return false;
+			}
+			catch (const std::exception& e) {
+				return false;
+			}
+		}
+	}
 	return true;
+}
+
+bool	RequestParser::_headersIndicateBody(Request const& request)
+{
+	UniqHeaders const& headers = request.getUniqHeaders();
+	return (headers.find("content-length") != headers.end() ||
+			headers.find("transfer-encoding") != headers.end());
 }
 
 bool	RequestParser::_isValidContentType(std::string const& contentType)

--- a/src/http/RequestParser.cpp
+++ b/src/http/RequestParser.cpp
@@ -491,24 +491,6 @@ bool	RequestParser::_isValidHeaderValue(std::string const& value, std::string co
 			return false;
 		if (value.empty() || value[0] == ':')
 			return false;
-		size_t colon = value.find(':');
-		if (colon != std::string::npos) {
-			std::string port = value.substr(colon + 1);
-			if (port.empty())
-				return false;
-			for (size_t i = 0; i < port.length(); ++i) {
-				if (!std::isdigit(port[i]))
-					return false;
-			}
-			try {
-				size_t portNum = utils::toSizeT(port);
-				if (portNum < 1 || portNum > 65535)
-					return false;
-			}
-			catch (const std::exception& e) {
-				return false;
-			}
-		}
 	}
 	return true;
 }

--- a/src/http/Response.cpp
+++ b/src/http/Response.cpp
@@ -91,11 +91,11 @@ bool	Response::isConnectionClose() const {
 
 // CGI
 
-Response	Response::initCgiResponse(RoutingDecision const& rd, std::string const& scriptName, HostPortPair const& listeningOn)
+Response	Response::initCgiResponse(RoutingDecision const& rd, std::string const& scriptName, HostPortPair const& listeningOn, std::string const& remoteAddr)
 {
 	Response resp;
 	resp._needsCgiExecution = true;
-	resp._cgiData = new CgiData(rd.getRequest(), *rd.getLocation(), scriptName, listeningOn);
+	resp._cgiData = new CgiData(rd.getRequest(), *rd.getLocation(), scriptName, listeningOn, remoteAddr);
 	//Log::dev("debug", "Pending CGI response data:\n" + utils::str(*resp._cgiData));
 	return resp;
 }

--- a/src/network/Client.cpp
+++ b/src/network/Client.cpp
@@ -8,6 +8,7 @@ Client::Client(int fd, Socket* socket, Network* network)
 , _lastActivity(time(NULL))
 , _responseSendPos(0)
 , _shouldCloseAfterResponse(false)
+, _remoteAddr("")
 {}
 
 Client::~Client()
@@ -152,6 +153,17 @@ bool	Client::shouldCloseAfterResponse() const
 	return _shouldCloseAfterResponse;
 }
 
+std::string const&	Client::getRemoteAddr() const
+{
+	return _remoteAddr;
+}
+
+// SETTERS
+
+void	Client::setRemoteAddr(const std::string& remoteAddr)
+{
+	_remoteAddr = remoteAddr;
+}
 
 // PRINT
 

--- a/src/network/Network.cpp
+++ b/src/network/Network.cpp
@@ -288,7 +288,7 @@ void	Network::_checkClientsInactivity()
 	for (size_t i = 0; i < _activeClients.size(); ++i) {
 		Client* client = _activeClients[i];
 		if (client->isInactive(now, _CLIENT_TIMEOUT_SECONDS)) {
-			Log::dev("close", "Client fd " + Log::hl(client->getFd()) + " disconnected for inactivity after " + Log::hl(_CLIENT_TIMEOUT_SECONDS) + " seconds.");
+			Log::dev("close", "Client fd " + Log::hl(client->getFd()) + " disconnected due to inactivity after " + Log::hl(_CLIENT_TIMEOUT_SECONDS) + " seconds.");
 			_disconnectClient(client);
 		}
 	}

--- a/src/network/Network.cpp
+++ b/src/network/Network.cpp
@@ -265,8 +265,7 @@ void Network::_dispatchAndSendResponse(Client* client)
 		HostPortPair listenDirective = listeningSocket->getListenDirective();
 		Log::prod("ok", req.getMethod() + " request received on " + Log::hl(listenDirective) + " (fd " + Log::hl(client->getFd()) + ").");
 		Log::dev("debug", "Request:\n" + utils::str(req));
-		std::string remoteAddr = client->getRemoteAddr();
-		Response response = Router::dispatchRequest(_config, req, listenDirective, remoteAddr);
+		Response response = Router::dispatchRequest(_config, req, listenDirective, client->getRemoteAddr());
 
 		if (response.needsCgiExecution()) { // CGI -> async response (stays in EPOLLIN to wait for CGI output)
 			_cgi.launchAsync(client->getFd(), response); // => Stay in EPOLLIN + ownership transfert of CgiData from Response to CgiContext

--- a/src/network/Network.cpp
+++ b/src/network/Network.cpp
@@ -266,7 +266,8 @@ void Network::_dispatchAndSendResponse(Client* client)
 		HostPortPair listenDirective = listeningSocket->getListenDirective();
 		Log::prod("ok", req.getMethod() + " request received on " + Log::hl(listenDirective) + " (fd " + Log::hl(client->getFd()) + ").");
 		//Log::dev("debug", "Request:\n" + utils::str(request));
-		Response response = Router::dispatchRequest(_config, req, listenDirective);
+		std::string remoteAddr = client->getRemoteAddr();
+		Response response = Router::dispatchRequest(_config, req, listenDirective, remoteAddr);
 
 		if (response.needsCgiExecution()) { // CGI -> async response (stays in EPOLLIN to wait for CGI output)
 			_cgi.launchAsync(client->getFd(), response); // => Stay in EPOLLIN + ownership transfert of CgiData from Response to CgiContext
@@ -393,10 +394,13 @@ Client* Network::_acceptNewClient(int listeningFd)
 {
 	for (size_t i = 0; i < _listeningSockets.size(); ++i) {
 		if (listeningFd == _listeningSockets[i]->getFd()) {
-			int clientFd =  _listeningSockets[i]->createNewClientSocket();
+			std::string clientIp;
+			int clientFd =  _listeningSockets[i]->createNewClientSocket(clientIp);
 			if (clientFd > 0) {
 				Client* client = new Client(clientFd, _listeningSockets[i], this);
+				client->setRemoteAddr(clientIp);
 				_activeClients.push_back(client);
+				Log::prod("event", "New client from " + Log::hl(clientIp) + " (fd " + Log::hl(clientFd) + ")");
 				return client;
 			}
 		}

--- a/src/network/Network.cpp
+++ b/src/network/Network.cpp
@@ -265,7 +265,7 @@ void Network::_dispatchAndSendResponse(Client* client)
 
 		HostPortPair listenDirective = listeningSocket->getListenDirective();
 		Log::prod("ok", req.getMethod() + " request received on " + Log::hl(listenDirective) + " (fd " + Log::hl(client->getFd()) + ").");
-		//Log::dev("debug", "Request:\n" + utils::str(request));
+		Log::dev("debug", "Request:\n" + utils::str(req));
 		std::string remoteAddr = client->getRemoteAddr();
 		Response response = Router::dispatchRequest(_config, req, listenDirective, remoteAddr);
 

--- a/src/network/Socket.cpp
+++ b/src/network/Socket.cpp
@@ -89,9 +89,9 @@ void	Socket::safeListen()
  * Accepts a new client connection on this listening socket.
  * Returns new client socket's fd (or -1 in case of accept() error).
  */
-int	Socket::createNewClientSocket()
+int	Socket::createNewClientSocket(std::string& clientIpOut)
 {
-	struct sockaddr_storage clientInfos;
+	struct sockaddr_in clientInfos;
 
 	socklen_t clientInfoSize = sizeof(clientInfos);
 	int newClientSocketFd = accept(_fd, (struct sockaddr*)&clientInfos, &clientInfoSize);
@@ -99,6 +99,7 @@ int	Socket::createNewClientSocket()
 		Log::prod("error", "accept(): " + utils::str(strerror(errno)));
 		return -1;
 	}
+	clientIpOut = utils::sockaddrInToIP(clientInfos);
 	//Log::dev("setup", "Setting Client socket to non-blocking mode...");
 	setNonBlocking(newClientSocketFd, true);
 	Log::dev("setup", "Socket accept() success.");

--- a/src/router/Router.cpp
+++ b/src/router/Router.cpp
@@ -12,7 +12,7 @@
  *   listing page if needed.
  * - It is the role of CgiHandler to check if the script exists and is executable.
  */
-Response	Router::dispatchRequest(Config const& config, Request const& req, HostPortPair const& listeningOn)
+Response	Router::dispatchRequest(Config const& config, Request const& req, HostPortPair const& listeningOn, std::string const& remoteAddr)
 {
 	RoutingDecision rd(config, req, listeningOn);
 	Log::dev("debug", "Routing Decision:\n" + utils::str(rd));
@@ -26,7 +26,7 @@ Response	Router::dispatchRequest(Config const& config, Request const& req, HostP
 	if (decision == RoutingDecision::REDIRECTION)
 		return _handleRedirectionDecision(rd);
 	if (decision == RoutingDecision::CGI)
-		return _handleCgiDecision(rd, listeningOn);
+		return _handleCgiDecision(rd, listeningOn, remoteAddr);
 	if (decision == RoutingDecision::STATIC)
 		return _handleStaticDecision(rd);
 	return StaticHandler::error("internal_server_error", rd);
@@ -39,10 +39,10 @@ Response	Router::_handleRedirectionDecision(RoutingDecision const& rd)
 	return redirect.run();
 }
 
-Response	Router::_handleCgiDecision(RoutingDecision const& rd, HostPortPair const& listeningOn)
+Response	Router::_handleCgiDecision(RoutingDecision const& rd, HostPortPair const& listeningOn, std::string const& remoteAddr)
 {
 	std::string const& scriptName = rd.getFinalPath();
-	return Response::initCgiResponse(rd, scriptName, listeningOn);
+	return Response::initCgiResponse(rd, scriptName, listeningOn, remoteAddr);
 }
 
 Response	Router::_handleStaticDecision(RoutingDecision const& rd)

--- a/src/static/StaticHandler.cpp
+++ b/src/static/StaticHandler.cpp
@@ -51,7 +51,10 @@ Response	StaticHandler::get(RoutingDecision const& rd)
 			resp.setConnectionFromRequest(req);
 			return resp;
 		}
-		return error("forbidden", rd);
+		else if (UBUNTU_TESTER)
+			return error("not_found", rd);
+		else
+			return error("forbidden", rd);
 	}
 	else if (utils::isReadableFile(finalPath))
 		return _serveFile(finalPath, rd);

--- a/src/static/StaticHandler.cpp
+++ b/src/static/StaticHandler.cpp
@@ -51,7 +51,7 @@ Response	StaticHandler::get(RoutingDecision const& rd)
 			resp.setConnectionFromRequest(req);
 			return resp;
 		}
-		return error("not_found", rd);
+		return error("forbidden", rd);
 	}
 	else if (utils::isReadableFile(finalPath))
 		return _serveFile(finalPath, rd);

--- a/src/utils/Log.cpp
+++ b/src/utils/Log.cpp
@@ -24,7 +24,7 @@ const Log::Category Log::_CATEGORIES[] = {
 	{"ok", _BOLD + _GREEN, _ACCESS_STREAM}, // Succeeded requests
 	{"event", _BLUE, _ACCESS_STREAM}, // Request event
 	{"status", _CYAN, _ACCESS_STREAM}, // Status, metrics
-	{"info", _BOLD + _YELLOW, _ACCESS_STREAM}, // General acitivity informations
+	{"info", _BOLD + _YELLOW, _ACCESS_STREAM}, // General activity information
 	{"cgi", _LIGHT_MAGENTA, _ACCESS_STREAM}, // CGI-related logs
 
 	{"error", _BOLD + _RED, _ERROR_STREAM}, // Critical errors

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -142,6 +142,18 @@ std::string	utils::toUpper(std::string const& s)
 	return up;
 }
 
+std::string	utils::sockaddrInToIP(const struct sockaddr_in& addr)
+{
+	size_t ip = ntohl(addr.sin_addr.s_addr); //to normalize to correct order
+	std::ostringstream oss;
+
+	oss << ((ip >> 24) & 0xFF) << "."
+		<< ((ip >> 16) & 0xFF) << "."
+		<< ((ip >> 8) & 0xFF) << "."
+		<< (ip & 0xFF);
+	return oss.str();
+}
+
 std::string	utils::readFile(std::string const& path)
 {
 	std::ifstream file(path.c_str(), std::ios::binary);


### PR DESCRIPTION
New feature : `REMOTE_ADDR` logic, since it seems to be required by RFC 3875.
If you're interested, the implementation was based on this discussion https://stackoverflow.com/questions/2064636/getting-the-source-address-of-an-incoming-socket-connection , I went with the logic the second asnwer says, because we cannot use  `getpeername()`. Obviously, without taking into account IPv6 IPs.

Since we have Client class now,  the IP is extracted at the moment of connection when accept() happens and stores it in the Client object. (`remote_addr` attribute inside Client and has setter/getter)

- `Socket::createNewClientSocket()` will return the client's IP. 
- `Network::_acceptNewClient()` will store the IP accoirdingly inside Client `client->setRemoteAddr(clientIp);` and added a log to show that, (run the program and visit any site to see the log with the client's IP).
- Router passes IP from Cient to CGIHandler
- CgiData stores it and includes both `REMOTE_ADDR` and `REMOTE_HOST` in the CGI environment. According to the RFC, `REMOTE_HOST` is the same as `REMOTE_ADDR` unless we had implemented reverse DNS resolution (translating IP to hostname), which it's not required. `REMOTE_HOST` isn't even a MUST required env variable anyway.

You can test and see that inside env.py if you like, what both env variables output!

Fixes :
- Fixed back for autoindex off to return 403 instead of 404 (we had changed that for the ubuntu_tester, but 403 is more correct if you agree and I wouldn't want anyoen to fail us for this detail). Instead of that, I can put  `if (UBUNTU_TESTER) ` but I considered that overkill...
- Fixed inside parser for Host header to return `400` for empty value, or ";" (exactly as nginx behaves)
- Fixed this to show `Log::dev("close", "Disconnecting client (fd " + Log::hl(client->getFd()) + ") due to inactivity.");` instead of "for inactivity" which is better in regards ro English grammar, if you don't mind
- Added comments about the type of class in .hpp files for these classes : Client, CGIData, CGIHandler
- Added an if condition `if (UBUNTU_TESTER) ` inside `CgiData::_setEnvStorage` because PATH_INFO displays wrong info so far in this way, we only changed that because of the tester. Consequently, `tmp["PATH_TRANSLATED"] `will show the correct value as well for the prod.


This is a draft for you to see and review the changes, tomorrow I will run the final tests, see if anything else to be changed, and if you approve I will turn this to a PULL request!